### PR TITLE
[minor] Support resilient Direct VPC egress

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -8,9 +8,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.title, 'skip-release')
-    uses: libops/.github/.github/workflows/bump-release.yaml@main
+    uses: libops/.github/.github/workflows/bump-release.yaml@3bdb895c3fd05490b0c6a1341e630ac554842468 # main
     permissions:
       contents: write
       actions: write
-    secrets: inherit
-

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -2,6 +2,7 @@ name: Lint and Test
 
 on:
   push:
+  pull_request:
 
 jobs:
   lint-test:
@@ -14,12 +15,12 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
-          terraform_version: latest
+          terraform_version: 1.15.2
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "stable"
+          go-version: "1.26.5"
 
       - name: Install terraform-docs
         run: go install github.com/terraform-docs/terraform-docs@v0.20.0
@@ -44,3 +45,6 @@ jobs:
 
       - name: Terraform Validate
         run: terraform validate
+
+      - name: Terraform Test
+        run: terraform test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
-.PHONY: docs
+.PHONY: docs test
 docs:
 	terraform-docs markdown table --output-file README.md .
+
+test:
+	terraform fmt -check -recursive .
+	terraform init -backend=false
+	terraform validate
+	terraform test

--- a/README.md
+++ b/README.md
@@ -4,17 +4,48 @@ Terraform module for a multi-region [Google Cloud Run v2 Service](https://regist
 
 Variables support GPUs, GCS mounts, multi-containers, service ingress, custom audiences, request timeout, max concurrency, labels, and startup/liveness HTTP probes.
 
+## Direct VPC egress
+
+Set `vpc_direct_egress` to `PRIVATE_RANGES_ONLY` or `ALL_TRAFFIC`. The module retains its compatible `default` network and subnet defaults. To configure only one interface field, set the other explicitly to `null`; Cloud Run then infers the omitted network or same-named regional subnet as described in [Direct VPC configuration](https://cloud.google.com/run/docs/configuring/vpc-direct-vpc). Enabling egress with both fields set to `null` is rejected during planning. A fully qualified subnet must embed the same region as each Cloud Run service. For a multi-region service, use network-only inference with a same-named subnet in every region or use separate module instances so each region receives an explicit subnet.
+
+Direct VPC is the outbound VPC leg for Cloud Run services; it does not provide Direct VPC ingress to a service. Requests can still enter through the service's configured Cloud Run ingress, but a service reaching a VM or other private destination uses Direct VPC egress.
+
+This module configures the Cloud Run attachment, but the caller owns its network prerequisites. Use an IPv4 subnet of `/26` or larger from RFC 1918, RFC 6598 (`100.64.0.0/10`), or Class E (`240.0.0.0/4`), and retain Google Cloud's default network MTU of 1460. The Cloud Run service agent normally receives `roles/run.serviceAgent` in its service project. For Shared VPC, grant that service-project agent either `roles/compute.networkUser` on the host project, or `roles/compute.networkViewer` on the host project plus `roles/compute.networkUser` on the selected subnet. Authorize destination ingress from the entire subnet CIDR rather than ephemeral instance addresses; Cloud Run network tags and service identities cannot identify the source of an ingress firewall rule.
+
+Cloud Run reserves addresses in `/28` blocks during scale-up and uses roughly twice the steady-state instance count. Leave additional capacity for overlapping revisions, and wait 1–2 hours after disconnecting Cloud Run before deleting a subnet. Applications must tolerate occasional connection resets during network maintenance. If all traffic exits through Cloud NAT, account for the documented cold-start delay or evaluate a Serverless VPC Access connector when startup latency is more important than connector cost.
+
+## HTTP startup probes
+
+The legacy `startup_probe = "/startup"` container attribute remains supported. Use `startup_probe_config` when timing controls are required:
+
+```hcl
+containers = [{
+  image = "us-docker.pkg.dev/example/project/app:latest"
+  name  = "app"
+  port  = 8080
+  startup_probe_config = {
+    path                  = "/startup"
+    initial_delay_seconds = 10
+    timeout_seconds       = 2
+    period_seconds        = 5
+    failure_threshold     = 12
+  }
+}]
+```
+
+Probe settings are validated against [Cloud Run's startup-probe limits](https://cloud.google.com/run/docs/configuring/healthchecks). If both forms are set, `startup_probe_config` takes precedence. For Direct VPC readiness, the endpoint must verify a connection to an egress dependency before reporting success; either the endpoint can retry internally or it can return failure so Cloud Run retries it within the configured period and threshold window. A generic process-only endpoint does not cover the documented startup connection delay. Probe paths are part of the service's HTTP surface and are reachable by clients allowed through its ingress and authentication policy, so keep responses non-sensitive and make the handler free of state-changing side effects.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 7.0 |
 
 ## Modules
@@ -24,7 +55,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_cloud_run_v2_service.cloudrun](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service) | resource |
 | [google_cloud_run_v2_service_iam_member.invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service_iam_member) | resource |
 | [google_compute_backend_service.backend](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
@@ -34,9 +65,9 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_addl_env_vars"></a> [addl\_env\_vars](#input\_addl\_env\_vars) | Additional environment variables to set in containers | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
-| <a name="input_containers"></a> [containers](#input\_containers) | List of container configurations to run in the service. At least one container needs a port. This allows easily configuring multi-container deployments. | <pre>list(object({<br/>    image          = string<br/>    name           = string<br/>    command        = optional(list(string), null)<br/>    args           = optional(list(string), null)<br/>    port           = optional(number, 0)<br/>    memory         = optional(string, "512Mi")<br/>    cpu            = optional(string, "1000m")<br/>    liveness_probe = optional(string, "")<br/>    startup_probe  = optional(string, "")<br/>    gpus           = optional(string, "")<br/>    volume_mounts = optional(list(object({<br/>      name       = string<br/>      mount_path = string<br/>    })), [])<br/>  }))</pre> | n/a | yes |
+| <a name="input_containers"></a> [containers](#input\_containers) | List of container configurations to run in the service. At least one container needs a port. startup\_probe\_config takes precedence over the legacy startup\_probe path when both are set. | <pre>list(object({<br/>    image          = string<br/>    name           = string<br/>    command        = optional(list(string), null)<br/>    args           = optional(list(string), null)<br/>    port           = optional(number, 0)<br/>    memory         = optional(string, "512Mi")<br/>    cpu            = optional(string, "1000m")<br/>    liveness_probe = optional(string, "")<br/>    startup_probe  = optional(string, "")<br/>    startup_probe_config = optional(object({<br/>      path                  = string<br/>      initial_delay_seconds = optional(number, 0)<br/>      timeout_seconds       = optional(number, 1)<br/>      period_seconds        = optional(number, 10)<br/>      failure_threshold     = optional(number, 3)<br/>    }), null)<br/>    gpus = optional(string, "")<br/>    volume_mounts = optional(list(object({<br/>      name       = string<br/>      mount_path = string<br/>    })), [])<br/>  }))</pre> | n/a | yes |
 | <a name="input_custom_audiences"></a> [custom\_audiences](#input\_custom\_audiences) | Custom audiences accepted by each Cloud Run service. | `list(string)` | `[]` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection on the Cloud Run service. | `bool` | `false` | no |
 | <a name="input_empty_dir_volumes"></a> [empty\_dir\_volumes](#input\_empty\_dir\_volumes) | List of empty directory volumes to create and mount | <pre>list(object({<br/>    name       = string<br/>    size_limit = optional(string, "2Mi")<br/>  }))</pre> | `[]` | no |
@@ -55,15 +86,15 @@ No modules.
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | List of Secret Manager secrets to mount as environment variables | <pre>list(object({<br/>    name        = string<br/>    secret_id   = string<br/>    secret_name = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_skipNeg"></a> [skipNeg](#input\_skipNeg) | Skip creating Network Endpoint Group and Backend Service | `bool` | `false` | no |
 | <a name="input_timeout_seconds"></a> [timeout\_seconds](#input\_timeout\_seconds) | Optional request timeout for each Cloud Run service, in seconds. | `number` | `null` | no |
-| <a name="input_vpc_direct_egress"></a> [vpc\_direct\_egress](#input\_vpc\_direct\_egress) | Traffic VPC egress settings. Possible values are: `ALL_TRAFFIC`, `PRIVATE_RANGES_ONLY`. | `string` | `"OFF"` | no |
-| <a name="input_vpc_direct_egress_network"></a> [vpc\_direct\_egress\_network](#input\_vpc\_direct\_egress\_network) | The VPC network that the Cloud Run resource will be able to send traffic to | `string` | `"default"` | no |
-| <a name="input_vpc_direct_egress_subnetwork"></a> [vpc\_direct\_egress\_subnetwork](#input\_vpc\_direct\_egress\_subnetwork) | The VPC subnetwork that the Cloud Run resource will get IPs from | `string` | `"default"` | no |
+| <a name="input_vpc_direct_egress"></a> [vpc\_direct\_egress](#input\_vpc\_direct\_egress) | Traffic VPC egress setting. Set to `OFF`, `ALL_TRAFFIC`, or `PRIVATE_RANGES_ONLY`. | `string` | `"OFF"` | no |
+| <a name="input_vpc_direct_egress_network"></a> [vpc\_direct\_egress\_network](#input\_vpc\_direct\_egress\_network) | VPC network for Direct VPC egress. Set this or vpc\_direct\_egress\_subnetwork to null to let Cloud Run infer the omitted field. | `string` | `"default"` | no |
+| <a name="input_vpc_direct_egress_subnetwork"></a> [vpc\_direct\_egress\_subnetwork](#input\_vpc\_direct\_egress\_subnetwork) | VPC subnetwork from which Cloud Run receives IPs. Set this or vpc\_direct\_egress\_network to null to let Cloud Run infer the omitted field. | `string` | `"default"` | no |
 | <a name="input_vpc_direct_egress_tags"></a> [vpc\_direct\_egress\_tags](#input\_vpc\_direct\_egress\_tags) | Network tags applied to this Cloud Run service | `list(string)` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_backend"></a> [backend](#output\_backend) | Backend service ID for load balancer (empty if skipNeg is true) |
 | <a name="output_name"></a> [name](#output\_name) | Map of region to Cloud Run service names |
 | <a name="output_url"></a> [url](#output\_url) | Primary Cloud Run service URL (first region) |

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,23 @@ terraform {
   }
 }
 
+locals {
+  vpc_direct_egress_network = (
+    try(trimspace(var.vpc_direct_egress_network), "") == ""
+    ? null
+    : trimspace(var.vpc_direct_egress_network)
+  )
+  vpc_direct_egress_subnetwork = (
+    try(trimspace(var.vpc_direct_egress_subnetwork), "") == ""
+    ? null
+    : trimspace(var.vpc_direct_egress_subnetwork)
+  )
+  vpc_direct_egress_subnetwork_region = try(
+    regex("projects/[^/]+/regions/([^/]+)/subnetworks/[^/]+$", local.vpc_direct_egress_subnetwork)[0],
+    null,
+  )
+}
+
 data "google_service_account" "service_account" {
   account_id = var.gsa
   project    = var.project
@@ -23,6 +40,25 @@ resource "google_cloud_run_v2_service" "cloudrun" {
 
   deletion_protection = var.deletion_protection
   custom_audiences    = var.custom_audiences
+
+  lifecycle {
+    precondition {
+      condition = (
+        var.vpc_direct_egress == "OFF"
+        || local.vpc_direct_egress_network != null
+        || local.vpc_direct_egress_subnetwork != null
+      )
+      error_message = "Direct VPC egress requires vpc_direct_egress_network, vpc_direct_egress_subnetwork, or both."
+    }
+    precondition {
+      condition = (
+        var.vpc_direct_egress == "OFF"
+        || local.vpc_direct_egress_subnetwork_region == null
+        || local.vpc_direct_egress_subnetwork_region == each.key
+      )
+      error_message = "A fully qualified Direct VPC subnetwork must belong to the Cloud Run service region."
+    }
+  }
 
   scaling {
     min_instance_count = var.min_instances
@@ -61,10 +97,18 @@ resource "google_cloud_run_v2_service" "cloudrun" {
         }
 
         dynamic "startup_probe" {
-          for_each = containers.value.startup_probe != "" ? [containers.value.startup_probe] : []
+          for_each = (
+            containers.value.startup_probe_config != null
+            || containers.value.startup_probe != ""
+          ) ? [true] : []
           content {
+            initial_delay_seconds = try(containers.value.startup_probe_config.initial_delay_seconds, null)
+            timeout_seconds       = try(containers.value.startup_probe_config.timeout_seconds, null)
+            period_seconds        = try(containers.value.startup_probe_config.period_seconds, null)
+            failure_threshold     = try(containers.value.startup_probe_config.failure_threshold, null)
+
             http_get {
-              path = startup_probe.value
+              path = try(containers.value.startup_probe_config.path, containers.value.startup_probe)
             }
           }
         }
@@ -133,8 +177,8 @@ resource "google_cloud_run_v2_service" "cloudrun" {
       content {
         egress = var.vpc_direct_egress
         network_interfaces {
-          network    = var.vpc_direct_egress_network
-          subnetwork = var.vpc_direct_egress_subnetwork
+          network    = local.vpc_direct_egress_network
+          subnetwork = local.vpc_direct_egress_subnetwork
           tags       = var.vpc_direct_egress_tags
         }
       }

--- a/tests/cloudrun.tftest.hcl
+++ b/tests/cloudrun.tftest.hcl
@@ -1,0 +1,325 @@
+mock_provider "google" {
+  mock_data "google_service_account" {
+    defaults = {
+      email = "cloudrun@example-project.iam.gserviceaccount.com"
+    }
+  }
+}
+
+variables {
+  name     = "example"
+  gsa      = "cloudrun"
+  project  = "example-project"
+  regions  = ["us-central1"]
+  skipNeg  = true
+  invokers = []
+  containers = [{
+    image = "us-docker.pkg.dev/cloudrun/container/hello"
+    name  = "app"
+    port  = 8080
+  }]
+}
+
+run "direct_vpc_off" {
+  command = plan
+
+  assert {
+    condition     = length(google_cloud_run_v2_service.cloudrun["us-central1"].template[0].vpc_access) == 0
+    error_message = "vpc_access must be omitted when Direct VPC egress is off."
+  }
+}
+
+run "direct_vpc_preserves_default_interface" {
+  command = plan
+
+  variables {
+    vpc_direct_egress = "PRIVATE_RANGES_ONLY"
+  }
+
+  assert {
+    condition = (
+      google_cloud_run_v2_service.cloudrun["us-central1"].template[0].vpc_access[0].network_interfaces[0].network == "default"
+      && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].vpc_access[0].network_interfaces[0].subnetwork == "default"
+    )
+    error_message = "The compatible default network and subnetwork must be preserved."
+  }
+}
+
+run "direct_vpc_network_only" {
+  command = plan
+
+  variables {
+    vpc_direct_egress            = "PRIVATE_RANGES_ONLY"
+    vpc_direct_egress_network    = "projects/example-project/global/networks/app"
+    vpc_direct_egress_subnetwork = null
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.cloudrun["us-central1"].template[0].vpc_access[0].network_interfaces[0].network == "projects/example-project/global/networks/app"
+    error_message = "The configured network must be rendered."
+  }
+
+  assert {
+    condition     = local.vpc_direct_egress_subnetwork == null
+    error_message = "An omitted subnetwork must be passed to the provider as null."
+  }
+}
+
+run "direct_vpc_subnetwork_only" {
+  command = plan
+
+  variables {
+    vpc_direct_egress            = "ALL_TRAFFIC"
+    vpc_direct_egress_network    = null
+    vpc_direct_egress_subnetwork = "projects/example-project/regions/us-central1/subnetworks/app"
+  }
+
+  assert {
+    condition     = local.vpc_direct_egress_network == null
+    error_message = "An omitted network must be passed to the provider as null."
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.cloudrun["us-central1"].template[0].vpc_access[0].network_interfaces[0].subnetwork == "projects/example-project/regions/us-central1/subnetworks/app"
+    error_message = "The configured subnetwork must be rendered."
+  }
+}
+
+run "direct_vpc_rejects_subnetwork_from_another_region" {
+  command = plan
+
+  variables {
+    vpc_direct_egress            = "PRIVATE_RANGES_ONLY"
+    vpc_direct_egress_network    = "projects/example-project/global/networks/app"
+    vpc_direct_egress_subnetwork = "projects/example-project/regions/us-east1/subnetworks/app"
+  }
+
+  expect_failures = [
+    google_cloud_run_v2_service.cloudrun["us-central1"],
+  ]
+}
+
+run "direct_vpc_rejects_one_regional_subnetwork_for_multiple_regions" {
+  command = plan
+
+  variables {
+    regions                      = ["us-central1", "us-east1"]
+    vpc_direct_egress            = "PRIVATE_RANGES_ONLY"
+    vpc_direct_egress_network    = "projects/example-project/global/networks/app"
+    vpc_direct_egress_subnetwork = "projects/example-project/regions/us-central1/subnetworks/app"
+  }
+
+  expect_failures = [
+    google_cloud_run_v2_service.cloudrun["us-east1"],
+  ]
+}
+
+run "direct_vpc_network_and_subnetwork" {
+  command = plan
+
+  variables {
+    vpc_direct_egress            = "PRIVATE_RANGES_ONLY"
+    vpc_direct_egress_network    = "app"
+    vpc_direct_egress_subnetwork = "app-us-central1"
+  }
+
+  assert {
+    condition = (
+      google_cloud_run_v2_service.cloudrun["us-central1"].template[0].vpc_access[0].network_interfaces[0].network == "app"
+      && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].vpc_access[0].network_interfaces[0].subnetwork == "app-us-central1"
+    )
+    error_message = "Both network interface fields must be rendered when configured."
+  }
+}
+
+run "direct_vpc_requires_an_interface" {
+  command = plan
+
+  variables {
+    vpc_direct_egress            = "PRIVATE_RANGES_ONLY"
+    vpc_direct_egress_network    = null
+    vpc_direct_egress_subnetwork = null
+  }
+
+  expect_failures = [
+    google_cloud_run_v2_service.cloudrun,
+  ]
+}
+
+run "legacy_startup_probe_path" {
+  command = plan
+
+  variables {
+    containers = [{
+      image         = "us-docker.pkg.dev/cloudrun/container/hello"
+      name          = "app"
+      port          = 8080
+      startup_probe = "/legacy-startup"
+    }]
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].http_get[0].path == "/legacy-startup"
+    error_message = "The legacy startup_probe string must continue to render an HTTP probe."
+  }
+}
+
+run "structured_startup_probe" {
+  command = plan
+
+  variables {
+    containers = [{
+      image         = "us-docker.pkg.dev/cloudrun/container/hello"
+      name          = "app"
+      port          = 8080
+      startup_probe = "ignored-legacy-startup"
+      startup_probe_config = {
+        path                  = "/startup"
+        initial_delay_seconds = 12
+        timeout_seconds       = 4
+        period_seconds        = 8
+        failure_threshold     = 20
+      }
+    }]
+  }
+
+  assert {
+    condition = (
+      google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].http_get[0].path == "/startup"
+      && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].initial_delay_seconds == 12
+      && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].timeout_seconds == 4
+      && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].period_seconds == 8
+      && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].failure_threshold == 20
+    )
+    error_message = "The structured startup probe must render all configured HTTP probe fields."
+  }
+}
+
+run "legacy_startup_probe_rejects_non_absolute_path" {
+  command = plan
+
+  variables {
+    containers = [{
+      image         = "us-docker.pkg.dev/cloudrun/container/hello"
+      name          = "app"
+      startup_probe = "startup"
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "startup_probe_rejects_initial_delay_out_of_range" {
+  command = plan
+
+  variables {
+    containers = [{
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      name  = "app"
+      startup_probe_config = {
+        path                  = "/startup"
+        initial_delay_seconds = 241
+      }
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "startup_probe_rejects_empty_path" {
+  command = plan
+
+  variables {
+    containers = [{
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      name  = "app"
+      startup_probe_config = {
+        path = ""
+      }
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "startup_probe_rejects_non_absolute_path" {
+  command = plan
+
+  variables {
+    containers = [{
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      name  = "app"
+      startup_probe_config = {
+        path = "startup"
+      }
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "startup_probe_rejects_whitespace_in_path" {
+  command = plan
+
+  variables {
+    containers = [{
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      name  = "app"
+      startup_probe_config = {
+        path = "/startup probe"
+      }
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "startup_probe_rejects_timeout_greater_than_period" {
+  command = plan
+
+  variables {
+    containers = [{
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      name  = "app"
+      startup_probe_config = {
+        path            = "/startup"
+        timeout_seconds = 11
+        period_seconds  = 10
+      }
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "startup_probe_rejects_failure_window_over_240_seconds" {
+  command = plan
+
+  variables {
+    containers = [{
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      name  = "app"
+      startup_probe_config = {
+        path              = "/startup"
+        period_seconds    = 20
+        failure_threshold = 13
+      }
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -143,13 +143,112 @@ variable "containers" {
     cpu            = optional(string, "1000m")
     liveness_probe = optional(string, "")
     startup_probe  = optional(string, "")
-    gpus           = optional(string, "")
+    startup_probe_config = optional(object({
+      path                  = string
+      initial_delay_seconds = optional(number, 0)
+      timeout_seconds       = optional(number, 1)
+      period_seconds        = optional(number, 10)
+      failure_threshold     = optional(number, 3)
+    }), null)
+    gpus = optional(string, "")
     volume_mounts = optional(list(object({
       name       = string
       mount_path = string
     })), [])
   }))
-  description = "List of container configurations to run in the service. At least one container needs a port. This allows easily configuring multi-container deployments."
+  description = "List of container configurations to run in the service. At least one container needs a port. startup_probe_config takes precedence over the legacy startup_probe path when both are set."
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : (
+        container.startup_probe_config != null
+        || container.startup_probe == ""
+        || can(regex("^/[^[:space:][:cntrl:]]*$", container.startup_probe))
+      )
+    ])
+    error_message = "startup_probe must be empty or begin with / and contain no whitespace or control characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : (
+        container.startup_probe_config == null
+        ? true
+        : try(
+          can(regex("^/[^[:space:][:cntrl:]]*$", container.startup_probe_config.path)),
+          false,
+        )
+      )
+    ])
+    error_message = "startup_probe_config.path must begin with / and contain no whitespace or control characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : try(
+        container.startup_probe_config.initial_delay_seconds >= 0
+        && container.startup_probe_config.initial_delay_seconds <= 240
+        && floor(container.startup_probe_config.initial_delay_seconds) == container.startup_probe_config.initial_delay_seconds,
+        true
+      )
+    ])
+    error_message = "startup_probe_config.initial_delay_seconds must be a whole number from 0 through 240."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : try(
+        container.startup_probe_config.timeout_seconds >= 1
+        && container.startup_probe_config.timeout_seconds <= 240
+        && floor(container.startup_probe_config.timeout_seconds) == container.startup_probe_config.timeout_seconds,
+        true
+      )
+    ])
+    error_message = "startup_probe_config.timeout_seconds must be a whole number from 1 through 240."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : try(
+        container.startup_probe_config.period_seconds >= 1
+        && container.startup_probe_config.period_seconds <= 240
+        && floor(container.startup_probe_config.period_seconds) == container.startup_probe_config.period_seconds,
+        true
+      )
+    ])
+    error_message = "startup_probe_config.period_seconds must be a whole number from 1 through 240."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : try(
+        container.startup_probe_config.failure_threshold >= 1
+        && floor(container.startup_probe_config.failure_threshold) == container.startup_probe_config.failure_threshold,
+        true
+      )
+    ])
+    error_message = "startup_probe_config.failure_threshold must be a positive whole number."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : try(
+        container.startup_probe_config.timeout_seconds <= container.startup_probe_config.period_seconds,
+        true
+      )
+    ])
+    error_message = "startup_probe_config.timeout_seconds must be less than or equal to period_seconds."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : try(
+        container.startup_probe_config.failure_threshold * container.startup_probe_config.period_seconds <= 240,
+        true
+      )
+    ])
+    error_message = "startup_probe_config.failure_threshold multiplied by period_seconds must not exceed 240 seconds."
+  }
 }
 
 variable "addl_env_vars" {
@@ -184,24 +283,24 @@ variable "gcs_volumes" {
 
 variable "vpc_direct_egress" {
   type        = string
-  description = "Traffic VPC egress settings. Possible values are: `ALL_TRAFFIC`, `PRIVATE_RANGES_ONLY`."
+  description = "Traffic VPC egress setting. Set to `OFF`, `ALL_TRAFFIC`, or `PRIVATE_RANGES_ONLY`."
   default     = "OFF"
   validation {
     condition     = contains(["OFF", "ALL_TRAFFIC", "PRIVATE_RANGES_ONLY"], var.vpc_direct_egress)
-    error_message = "The 'vpc_direct_egress' variable must be one of 'ALL_TRAFFIC' or 'PRIVATE_RANGES_ONLY'"
+    error_message = "vpc_direct_egress must be one of OFF, ALL_TRAFFIC, or PRIVATE_RANGES_ONLY."
   }
 }
 
 variable "vpc_direct_egress_network" {
   type        = string
-  description = "The VPC network that the Cloud Run resource will be able to send traffic to"
+  description = "VPC network for Direct VPC egress. Set this or vpc_direct_egress_subnetwork to null to let Cloud Run infer the omitted field."
   default     = "default"
 }
 
 variable "vpc_direct_egress_subnetwork" {
   type        = string
   default     = "default"
-  description = "The VPC subnetwork that the Cloud Run resource will get IPs from"
+  description = "VPC subnetwork from which Cloud Run receives IPs. Set this or vpc_direct_egress_network to null to let Cloud Run infer the omitted field."
 }
 
 variable "vpc_direct_egress_tags" {


### PR DESCRIPTION
## Summary

- add validated per-region Direct VPC network and subnetwork interfaces while preserving the existing default interface
- support structured startup probes with a bounded retry window for Direct VPC cold starts
- retain the legacy probe path for compatible downstream upgrades
- pin release workflow dependencies and exercise valid and invalid network and probe shapes

## Verification

- `make test`
- 17 Terraform tests passed
- Terraform formatting and validation passed

## Dependency

cloud-compose should pin the merged immutable commit before its GCP runtime PR is merged.