### PR TITLE
[minor] Support ordered sidecar startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform module for a multi-region [Google Cloud Run v2 Service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service) behind a [serverless Network Endpoint Group (NEG)](https://cloud.google.com/load-balancing/docs/negs/serverless-neg-concepts).
 
-Variables support GPUs, GCS mounts, multi-containers, service ingress, custom audiences, request timeout, max concurrency, labels, and startup/liveness HTTP probes.
+Variables support GPUs, GCS mounts, ordered multi-container startup, service ingress, custom audiences, request timeout, max concurrency, labels, and startup/liveness HTTP probes.
 
 ## Direct VPC egress
 
@@ -29,6 +29,7 @@ containers = [{
   port  = 8080
   startup_probe_config = {
     path                  = "/startup"
+    port                  = 8080
     initial_delay_seconds = 10
     timeout_seconds       = 2
     period_seconds        = 5
@@ -38,6 +39,37 @@ containers = [{
 ```
 
 Probe settings are validated against [Cloud Run's startup-probe limits](https://cloud.google.com/run/docs/configuring/healthchecks). If both forms are set, `startup_probe_config` takes precedence. For Direct VPC readiness, the endpoint must verify a connection to an egress dependency before reporting success; either the endpoint can retry internally or it can return failure so Cloud Run retries it within the configured period and threshold window. A generic process-only endpoint does not cover the documented startup connection delay. Probe paths are part of the service's HTTP surface and are reachable by clients allowed through its ingress and authentication policy, so keep responses non-sensitive and make the handler free of state-changing side effects.
+
+For a multi-container service, set `depends_on` on the dependent container and
+give every dependency a startup probe. Cloud Run waits for those probes before
+starting the dependent container:
+
+```hcl
+containers = [
+  {
+    image = "us-docker.pkg.dev/example/project/vault@sha256:..."
+    name  = "vault"
+    startup_probe_config = {
+      path              = "/v1/sys/health?uninitcode=200"
+      port              = 8200
+      timeout_seconds   = 2
+      period_seconds    = 5
+      failure_threshold = 48
+    }
+  },
+  {
+    image      = "us-docker.pkg.dev/example/project/proxy@sha256:..."
+    name       = "proxy"
+    port       = 8080
+    depends_on = ["vault"]
+  },
+]
+```
+
+List dependencies before the containers that depend on them. Dependency names
+must be unique container names in the same service. Self, duplicate, forward,
+and unknown dependencies are rejected during planning, which also prevents
+dependency cycles.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -71,7 +103,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_addl_env_vars"></a> [addl\_env\_vars](#input\_addl\_env\_vars) | Additional environment variables to set in containers | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
-| <a name="input_containers"></a> [containers](#input\_containers) | List of container configurations to run in the service. At least one container needs a port. startup\_probe\_config takes precedence over the legacy startup\_probe path when both are set. | <pre>list(object({<br/>    image          = string<br/>    name           = string<br/>    command        = optional(list(string), null)<br/>    args           = optional(list(string), null)<br/>    port           = optional(number, 0)<br/>    memory         = optional(string, "512Mi")<br/>    cpu            = optional(string, "1000m")<br/>    liveness_probe = optional(string, "")<br/>    startup_probe  = optional(string, "")<br/>    startup_probe_config = optional(object({<br/>      path                  = string<br/>      initial_delay_seconds = optional(number, 0)<br/>      timeout_seconds       = optional(number, 1)<br/>      period_seconds        = optional(number, 10)<br/>      failure_threshold     = optional(number, 3)<br/>    }), null)<br/>    gpus = optional(string, "")<br/>    volume_mounts = optional(list(object({<br/>      name       = string<br/>      mount_path = string<br/>    })), [])<br/>  }))</pre> | n/a | yes |
+| <a name="input_containers"></a> [containers](#input\_containers) | List of container configurations to run in the service. At least one container needs a port. depends\_on names containers that must pass their startup probes before this container starts. startup\_probe\_config takes precedence over the legacy startup\_probe path when both are set. | <pre>list(object({<br/>    image          = string<br/>    name           = string<br/>    command        = optional(list(string), null)<br/>    args           = optional(list(string), null)<br/>    depends_on     = optional(list(string), [])<br/>    port           = optional(number, 0)<br/>    memory         = optional(string, "512Mi")<br/>    cpu            = optional(string, "1000m")<br/>    liveness_probe = optional(string, "")<br/>    startup_probe  = optional(string, "")<br/>    startup_probe_config = optional(object({<br/>      path                  = string<br/>      port                  = optional(number, null)<br/>      initial_delay_seconds = optional(number, 0)<br/>      timeout_seconds       = optional(number, 1)<br/>      period_seconds        = optional(number, 10)<br/>      failure_threshold     = optional(number, 3)<br/>    }), null)<br/>    gpus = optional(string, "")<br/>    volume_mounts = optional(list(object({<br/>      name       = string<br/>      mount_path = string<br/>    })), [])<br/>  }))</pre> | n/a | yes |
 | <a name="input_custom_audiences"></a> [custom\_audiences](#input\_custom\_audiences) | Custom audiences accepted by each Cloud Run service. | `list(string)` | `[]` | no |
 | <a name="input_default_uri_disabled"></a> [default\_uri\_disabled](#input\_default\_uri\_disabled) | Whether to disable the service's default run.app URL. This preview feature requires launch\_stage ALPHA or BETA. | `bool` | `false` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection on the Cloud Run service. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -81,10 +81,11 @@ resource "google_cloud_run_v2_service" "cloudrun" {
     dynamic "containers" {
       for_each = var.containers
       content {
-        image   = containers.value.image
-        name    = containers.value.name
-        command = containers.value.command
-        args    = containers.value.args
+        image      = containers.value.image
+        name       = containers.value.name
+        command    = containers.value.command
+        args       = containers.value.args
+        depends_on = containers.value.depends_on
         dynamic "ports" {
           for_each = containers.value.port != 0 ? [containers.value.port] : []
           content {
@@ -114,6 +115,7 @@ resource "google_cloud_run_v2_service" "cloudrun" {
 
             http_get {
               path = try(containers.value.startup_probe_config.path, containers.value.startup_probe)
+              port = try(containers.value.startup_probe_config.port, null)
             }
           }
         }

--- a/tests/cloudrun.tftest.hcl
+++ b/tests/cloudrun.tftest.hcl
@@ -207,6 +207,7 @@ run "structured_startup_probe" {
       startup_probe = "ignored-legacy-startup"
       startup_probe_config = {
         path                  = "/startup"
+        port                  = 9090
         initial_delay_seconds = 12
         timeout_seconds       = 4
         period_seconds        = 8
@@ -218,6 +219,7 @@ run "structured_startup_probe" {
   assert {
     condition = (
       google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].http_get[0].path == "/startup"
+      && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].http_get[0].port == 9090
       && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].initial_delay_seconds == 12
       && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].timeout_seconds == 4
       && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].period_seconds == 8
@@ -225,6 +227,119 @@ run "structured_startup_probe" {
     )
     error_message = "The structured startup probe must render all configured HTTP probe fields."
   }
+}
+
+run "ordered_sidecar_startup" {
+  command = plan
+
+  variables {
+    containers = [
+      {
+        image = "us-docker.pkg.dev/example/vault"
+        name  = "vault"
+        startup_probe_config = {
+          path              = "/v1/sys/health?uninitcode=200"
+          port              = 8200
+          timeout_seconds   = 2
+          period_seconds    = 5
+          failure_threshold = 48
+        }
+      },
+      {
+        image      = "us-docker.pkg.dev/example/proxy"
+        name       = "proxy"
+        port       = 8080
+        depends_on = ["vault"]
+      },
+    ]
+  }
+
+  assert {
+    condition = (
+      google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[0].startup_probe[0].http_get[0].port == 8200
+      && google_cloud_run_v2_service.cloudrun["us-central1"].template[0].containers[1].depends_on == tolist(["vault"])
+    )
+    error_message = "A dependent ingress container must wait for the sidecar's port-specific startup probe."
+  }
+}
+
+run "container_dependency_rejects_unknown_name" {
+  command = plan
+
+  variables {
+    containers = [{
+      image      = "us-docker.pkg.dev/cloudrun/container/hello"
+      name       = "app"
+      port       = 8080
+      depends_on = ["missing"]
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "container_dependency_rejects_self_reference" {
+  command = plan
+
+  variables {
+    containers = [{
+      image      = "us-docker.pkg.dev/cloudrun/container/hello"
+      name       = "app"
+      port       = 8080
+      depends_on = ["app"]
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "container_dependency_rejects_forward_reference" {
+  command = plan
+
+  variables {
+    containers = [
+      {
+        image      = "us-docker.pkg.dev/example/proxy"
+        name       = "proxy"
+        port       = 8080
+        depends_on = ["vault"]
+      },
+      {
+        image = "us-docker.pkg.dev/example/vault"
+        name  = "vault"
+      },
+    ]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "containers_reject_duplicate_names" {
+  command = plan
+
+  variables {
+    containers = [
+      {
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+        name  = "app"
+        port  = 8080
+      },
+      {
+        image = "us-docker.pkg.dev/cloudrun/container/sidecar"
+        name  = "app"
+      },
+    ]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
 }
 
 run "legacy_startup_probe_rejects_non_absolute_path" {
@@ -235,6 +350,25 @@ run "legacy_startup_probe_rejects_non_absolute_path" {
       image         = "us-docker.pkg.dev/cloudrun/container/hello"
       name          = "app"
       startup_probe = "startup"
+    }]
+  }
+
+  expect_failures = [
+    var.containers,
+  ]
+}
+
+run "startup_probe_rejects_invalid_port" {
+  command = plan
+
+  variables {
+    containers = [{
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      name  = "app"
+      startup_probe_config = {
+        path = "/startup"
+        port = 0
+      }
     }]
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -144,6 +144,7 @@ variable "containers" {
     name           = string
     command        = optional(list(string), null)
     args           = optional(list(string), null)
+    depends_on     = optional(list(string), [])
     port           = optional(number, 0)
     memory         = optional(string, "512Mi")
     cpu            = optional(string, "1000m")
@@ -151,6 +152,7 @@ variable "containers" {
     startup_probe  = optional(string, "")
     startup_probe_config = optional(object({
       path                  = string
+      port                  = optional(number, null)
       initial_delay_seconds = optional(number, 0)
       timeout_seconds       = optional(number, 1)
       period_seconds        = optional(number, 10)
@@ -162,7 +164,40 @@ variable "containers" {
       mount_path = string
     })), [])
   }))
-  description = "List of container configurations to run in the service. At least one container needs a port. startup_probe_config takes precedence over the legacy startup_probe path when both are set."
+  description = "List of container configurations to run in the service. At least one container needs a port. depends_on names containers that must pass their startup probes before this container starts. startup_probe_config takes precedence over the legacy startup_probe path when both are set."
+
+  validation {
+    condition = (
+      length(var.containers) > 0 &&
+      length(distinct([for container in var.containers : container.name])) == length(var.containers) &&
+      alltrue([
+        for container in var.containers :
+        trimspace(container.name) != "" &&
+        can(regex("^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$", container.name))
+      ])
+    )
+    error_message = "containers must contain at least one entry with a unique, valid Cloud Run container name."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : (
+        length(distinct(container.depends_on)) == length(container.depends_on) &&
+        !contains(container.depends_on, container.name) &&
+        alltrue([
+          for dependency in container.depends_on :
+          (
+            contains([for candidate in var.containers : candidate.name], dependency) &&
+            try(
+              index([for candidate in var.containers : candidate.name], dependency),
+              length(var.containers),
+            ) < index([for candidate in var.containers : candidate.name], container.name)
+          )
+        ])
+      )
+    ])
+    error_message = "Each container dependency must name a preceding, different container exactly once."
+  }
 
   validation {
     condition = alltrue([
@@ -187,6 +222,21 @@ variable "containers" {
       )
     ])
     error_message = "startup_probe_config.path must begin with / and contain no whitespace or control characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for container in var.containers : try(
+        container.startup_probe_config.port == null
+        || (
+          container.startup_probe_config.port >= 1
+          && container.startup_probe_config.port <= 65535
+          && floor(container.startup_probe_config.port) == container.startup_probe_config.port
+        ),
+        true
+      )
+    ])
+    error_message = "startup_probe_config.port must be null or a whole number from 1 through 65535."
   }
 
   validation {


### PR DESCRIPTION
Adds container dependency ordering and port-aware structured startup probes for multi-container Cloud Run services.

Validates unique names and an acyclic preceding-container dependency graph, preserves the legacy probe path, and adds focused Terraform tests and documentation. This unblocks a Vault sidecar from proving port 8200 readiness before the ingress proxy starts.